### PR TITLE
refactor ToNumbas, Fix translatable jme strings & improve cli

### DIFF
--- a/numbas/src/jme/mod.rs
+++ b/numbas/src/jme/mod.rs
@@ -29,14 +29,15 @@ pub struct JMEString {
 impl_string_json_schema!(JMEString, "JMEString");
 
 impl std::convert::TryFrom<String> for JMEString {
-    type Error = String; // TODO
+    type Error = parser::ConsumeError;
     fn try_from(s: String) -> Result<Self, Self::Error> {
         let trimmed = s.trim();
         let ast = if trimmed.is_empty() {
             None
         } else {
-            let pairs = parser::parse_as_jme(&trimmed).map_err(|e| format!("{:?}", e))?;
-            let ast = parser::consume_one_expression(pairs).map_err(|e| format!("{:?}", e))?;
+            let pairs = parser::parse_as_jme(&trimmed)
+                .map_err(|e| parser::ConsumeError::JMEParseError(vec![e]))?;
+            let ast = parser::consume_one_expression(pairs)?;
             Some(ast)
         };
         Ok(Self {
@@ -62,14 +63,15 @@ pub struct EmbracedJMEString {
 impl_string_json_schema!(EmbracedJMEString, "EmbracedJMEString"); // maybe add pattern?
 
 impl std::convert::TryFrom<String> for EmbracedJMEString {
-    type Error = String; // TODO
+    type Error = parser::ConsumeError;
     fn try_from(s: String) -> Result<Self, Self::Error> {
         let trimmed = s.trim();
         let asts = if trimmed.is_empty() {
             None
         } else {
-            let pairs = parser::parse_as_embraced_jme(&trimmed).map_err(|e| format!("{:?}", e))?;
-            let asts = parser::consume_expressions(pairs).map_err(|e| format!("{:?}", e))?;
+            let pairs = parser::parse_as_embraced_jme(&trimmed)
+                .map_err(|e| parser::ConsumeError::JMEParseError(vec![e]))?;
+            let asts = parser::consume_expressions(pairs)?;
             Some(asts)
         };
         Ok(Self {
@@ -96,15 +98,15 @@ pub struct ContentAreaString {
 impl_string_json_schema!(ContentAreaString, "ContentAreaString");
 
 impl std::convert::TryFrom<String> for ContentAreaString {
-    type Error = String; // TODO
+    type Error = parser::ConsumeError;
     fn try_from(s: String) -> Result<Self, Self::Error> {
         let trimmed = s.trim();
         let asts = if trimmed.is_empty() {
             None
         } else {
-            let pairs = parser::parse_as_content_area(&trimmed).map_err(|e| format!("{:?}", e))?;
-            let asts =
-                parser::consume_content_area_expressions(pairs).map_err(|e| format!("{:?}", e))?;
+            let pairs = parser::parse_as_content_area(&trimmed)
+                .map_err(|e| parser::ConsumeError::HTMLParseError(vec![e]))?;
+            let asts = parser::consume_content_area_expressions(pairs)?;
             Some(asts)
         };
         Ok(Self {
@@ -131,15 +133,15 @@ pub struct JMENotesString {
 impl_string_json_schema!(JMENotesString, "JMENotesString");
 
 impl std::convert::TryFrom<String> for JMENotesString {
-    type Error = String; // TODO
+    type Error = parser::ConsumeError;
     fn try_from(s: String) -> Result<Self, Self::Error> {
         let trimmed = s.trim();
         let notes = if trimmed.is_empty() {
             None
         } else {
-            let pairs =
-                parser::parse_as_jme_script(&trimmed).map_err(|e| format!("Parsing: {:?}", e))?;
-            let notes = parser::consume_notes(pairs).map_err(|e| format!("Consuming: {:?}", e))?;
+            let pairs = parser::parse_as_jme_script(&trimmed)
+                .map_err(|e| parser::ConsumeError::JMEParseError(vec![e]))?;
+            let notes = parser::consume_notes(pairs)?;
             Some(notes)
         };
         Ok(Self {

--- a/rumbas/src/cli/compile.rs
+++ b/rumbas/src/cli/compile.rs
@@ -38,6 +38,7 @@ pub fn compile(matches: &clap::ArgMatches) {
             if exam.locales().0.is_none() {
                 log::error!("Locales not set!");
             } else {
+                let mut something_failed: bool = false;
                 for locale_item in exam.locales().unwrap().iter() {
                     let locale = locale_item.clone().unwrap().name.unwrap();
                     let numbas = exam.to_numbas_safe(&locale);
@@ -73,17 +74,20 @@ pub fn compile(matches: &clap::ArgMatches) {
                             match exam_write_res {
                                 numbas::exam::WriteResult::IOError(e) => {
                                     log::error!("Failed saving the exam file because of {}.", e);
-                                    std::process::exit(1);
+                                    something_failed = true;
                                 }
                                 numbas::exam::WriteResult::JSONError(e) => {
                                     log::error!(
                                         "Failed generating the exam file because of {}.",
                                         e
                                     );
-                                    std::process::exit(1);
+                                    something_failed = true;
                                 }
                                 numbas::exam::WriteResult::Ok => {
-                                    log::info!("Generated and saved exam file.");
+                                    log::info!(
+                                        "Generated and saved exam file for locale {}.",
+                                        locale
+                                    );
 
                                     let numbas_settings = exam.numbas_settings().clone().unwrap();
 
@@ -119,7 +123,7 @@ pub fn compile(matches: &clap::ArgMatches) {
                                             "{}",
                                             std::str::from_utf8(&output.stderr).unwrap()
                                         );
-                                        std::process::exit(1)
+                                        something_failed = true;
                                     }
                                 }
                             }
@@ -150,9 +154,12 @@ pub fn compile(matches: &clap::ArgMatches) {
                                     .collect::<Vec<_>>()
                                     .join("\n")
                             );
-                            std::process::exit(1)
+                            something_failed = true;
                         }
                     }
+                }
+                if something_failed {
+                    std::process::exit(1)
                 }
             }
         }

--- a/rumbas/src/cli/compile.rs
+++ b/rumbas/src/cli/compile.rs
@@ -40,7 +40,7 @@ pub fn compile(matches: &clap::ArgMatches) {
             } else {
                 for locale_item in exam.locales().unwrap().iter() {
                     let locale = locale_item.clone().unwrap().name.unwrap();
-                    let numbas = exam.to_numbas(&locale);
+                    let numbas = exam.to_numbas_safe(&locale);
                     match numbas {
                         Ok(res) => {
                             let numbas_exam_name = path.with_extension("exam");
@@ -126,9 +126,10 @@ pub fn compile(matches: &clap::ArgMatches) {
                         }
                         Err(check_result) => {
                             let missing_fields = check_result.missing_fields();
-                            let invalid_fields = check_result.invalid_fields();
+                            let invalid_yaml_fields = check_result.invalid_yaml_fields();
+                            let invalid_jme_fields = check_result.invalid_jme_fields();
                             log::error!(
-                                "Error when processing locale {}.\nFound {} missing fields:\n{}\nFound {} invalid fields:\n{}",
+                                "Error when processing locale {}.\nFound {} missing fields:\n{}\nFound {} invalid fields:\n{}\nFound {} invalid jme fields:\n{}\n",
                                 locale,
                                 missing_fields.len(),
                                 missing_fields
@@ -136,8 +137,14 @@ pub fn compile(matches: &clap::ArgMatches) {
                                     .map(|f| f.to_string())
                                     .collect::<Vec<_>>()
                                     .join("\n"),
-                                invalid_fields.len(),
-                                invalid_fields
+                                invalid_yaml_fields.len(),
+                                invalid_yaml_fields
+                                    .iter()
+                                    .map(|f| f.to_string())
+                                    .collect::<Vec<_>>()
+                                    .join("\n"),
+                                invalid_jme_fields.len(),
+                                invalid_jme_fields
                                     .iter()
                                     .map(|f| f.to_string())
                                     .collect::<Vec<_>>()

--- a/rumbas/src/cli/compile.rs
+++ b/rumbas/src/cli/compile.rs
@@ -129,32 +129,32 @@ pub fn compile(matches: &clap::ArgMatches) {
                             }
                         }
                         Err(check_result) => {
+                            something_failed = true;
                             let missing_fields = check_result.missing_fields();
                             let invalid_yaml_fields = check_result.invalid_yaml_fields();
                             let invalid_jme_fields = check_result.invalid_jme_fields();
-                            log::error!(
-                                "Error when processing locale {}.\nFound {} missing fields:\n{}\nFound {} invalid fields:\n{}\nFound {} invalid jme fields:\n{}\n",
-                                locale,
-                                missing_fields.len(),
-                                missing_fields
-                                    .iter()
-                                    .map(|f| f.to_string())
-                                    .collect::<Vec<_>>()
-                                    .join("\n"),
-                                invalid_yaml_fields.len(),
-                                invalid_yaml_fields
-                                    .iter()
-                                    .map(|f| f.to_string())
-                                    .collect::<Vec<_>>()
-                                    .join("\n"),
-                                invalid_jme_fields.len(),
-                                invalid_jme_fields
-                                    .iter()
-                                    .map(|f| f.to_string())
-                                    .collect::<Vec<_>>()
-                                    .join("\n")
-                            );
-                            something_failed = true;
+                            log::error!("Error when processing locale {}.", locale);
+                            if !missing_fields.is_empty() {
+                                log::error!("Found {} missing fields:", missing_fields.len());
+                                for (idx, error) in missing_fields.iter().enumerate() {
+                                    log::error!("{}\t{}", idx + 1, error.to_string());
+                                }
+                            }
+                            if !invalid_jme_fields.is_empty() {
+                                log::error!(
+                                    "Found {} invalid jme expressions:",
+                                    invalid_jme_fields.len()
+                                );
+                                for (idx, error) in invalid_jme_fields.iter().enumerate() {
+                                    log::error!("{}\t{}", idx + 1, error.to_string());
+                                }
+                            }
+                            if !invalid_yaml_fields.is_empty() {
+                                log::error!("Found {} invalid fields:", invalid_yaml_fields.len());
+                                for (idx, error) in invalid_yaml_fields.iter().enumerate() {
+                                    log::error!("{}\t{}", idx + 1, error.to_string());
+                                }
+                            }
                         }
                     }
                 }

--- a/rumbas/src/cli/import.rs
+++ b/rumbas/src/cli/import.rs
@@ -121,7 +121,7 @@ fn convert_exam(
     (
         {
             if let TranslatableString::NotTranslated(n) = name {
-                n.get_content(&String::new())
+                n.get_content("").unwrap()
             } else {
                 panic!("Should not happen");
             }

--- a/rumbas/src/data/default.rs
+++ b/rumbas/src/data/default.rs
@@ -251,7 +251,6 @@ macro_rules! handle {
     let default_files = default_files(path);
     //println!("Found {} default files.", default_files.len());
     for default_file in default_files.iter() {
-        if !exam.check().is_empty() {
             log::info!("Reading {}", default_file.get_path().display()); //TODO: debug
             let default_data = default_file.read_as_data().unwrap(); //TODO
                                                                      //TODO: always call overwrite
@@ -306,7 +305,7 @@ macro_rules! handle {
                 DefaultData::QuestionPartGapFillGapInformation(p) => handle_question_parts!(gap exam, p, Information),
 
             }
-        }
+
     }
 }
 }

--- a/rumbas/src/data/diagnostic_exam.rs
+++ b/rumbas/src/data/diagnostic_exam.rs
@@ -7,7 +7,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_group::QuestionGroup;
 use crate::data::template::{Value, ValueType};
 use crate::data::timing::Timing;
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::ToRumbas;
 use crate::data::translatable::TranslatableString;
 use schemars::JsonSchema;
@@ -36,142 +36,130 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for DiagnosticExam {
-    type NumbasType = numbas::exam::Exam;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::Exam> {
-        let check = self.check();
-        if check.is_empty() {
-            let basic_settings = numbas::exam::BasicExamSettings {
-                name: self.name.clone().unwrap().to_string(locale).unwrap(), //TODO: might fail, not checked
-                duration_in_seconds: self
-                    .timing
+impl ToNumbas<numbas::exam::Exam> for DiagnosticExam {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::Exam {
+        let basic_settings = numbas::exam::BasicExamSettings {
+            name: self.name.clone().unwrap().to_string(locale).unwrap(), //TODO: might fail, not checked
+            duration_in_seconds: self
+                .timing
+                .clone()
+                .unwrap()
+                .duration_in_seconds
+                .to_numbas(locale),
+            percentage_needed_to_pass: self
+                .feedback
+                .clone()
+                .unwrap()
+                .percentage_needed_to_pass
+                .to_numbas(locale),
+            show_question_group_names: Some(
+                self.navigation
                     .clone()
                     .unwrap()
-                    .duration_in_seconds
-                    .to_numbas(locale)
+                    .shared_data
+                    .unwrap()
+                    .show_names_of_question_groups
                     .unwrap(),
-                percentage_needed_to_pass: self
-                    .feedback
+            ),
+            show_student_name: Some(self.feedback.clone().unwrap().show_name_of_student.unwrap()),
+            allow_printing: Some(
+                self.navigation
                     .clone()
                     .unwrap()
-                    .percentage_needed_to_pass
-                    .to_numbas(locale)
+                    .shared_data
+                    .unwrap()
+                    .allow_printing
                     .unwrap(),
-                show_question_group_names: Some(
-                    self.navigation
-                        .clone()
-                        .unwrap()
-                        .shared_data
-                        .unwrap()
-                        .show_names_of_question_groups
-                        .unwrap(),
-                ),
-                show_student_name: Some(
-                    self.feedback.clone().unwrap().show_name_of_student.unwrap(),
-                ),
-                allow_printing: Some(
-                    self.navigation
-                        .clone()
-                        .unwrap()
-                        .shared_data
-                        .unwrap()
-                        .allow_printing
-                        .unwrap(),
-                ),
-            };
+            ),
+        };
 
-            let navigation = self.navigation.clone().unwrap().to_numbas(locale).unwrap();
+        let navigation = self.navigation.clone().unwrap().to_numbas(locale);
 
-            let timing = self.timing.clone().unwrap().to_numbas(locale).unwrap();
+        let timing = self.timing.clone().unwrap().to_numbas(locale);
 
-            let feedback = self.feedback.clone().unwrap().to_numbas(locale).unwrap();
+        let feedback = self.feedback.clone().unwrap().to_numbas(locale);
 
-            //TODO
-            let functions = Value::Normal(HashMap::new());
+        //TODO
+        let functions = Value::Normal(HashMap::new());
 
-            //TODO
-            let variables = Value::Normal(HashMap::new());
+        //TODO
+        let variables = Value::Normal(HashMap::new());
 
-            let question_groups: Vec<numbas::exam::ExamQuestionGroup> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .map(|qg| qg.clone().to_numbas(locale).unwrap())
-                .collect();
+        let question_groups: Vec<numbas::exam::ExamQuestionGroup> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .map(|qg| qg.clone().to_numbas(locale))
+            .collect();
 
-            let resources: Vec<numbas::exam::Resource> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .flat_map(|qg| {
-                    qg.clone()
-                        .unwrap()
-                        .questions
-                        .unwrap()
-                        .into_iter()
-                        .flat_map(|q| q.unwrap().question_data.resources.unwrap())
-                })
-                .map(|r| r.unwrap())
-                .collect::<std::collections::HashSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>()
-                .to_numbas(locale)
-                .unwrap();
-
-            let extensions: Vec<String> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .flat_map(|qg| {
-                    qg.clone()
-                        .unwrap()
-                        .questions
-                        .unwrap()
-                        .into_iter()
-                        .map(|q| q.unwrap().question_data.extensions.unwrap())
-                })
-                .fold(Extensions::default(), Extensions::combine)
-                .to_paths();
-
-            let custom_part_types: Vec<numbas::exam::CustomPartType> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .flat_map(|qg| {
-                    qg.clone()
-                        .unwrap()
-                        .questions
-                        .unwrap()
-                        .into_iter()
-                        .flat_map(|q| q.unwrap().question_data.custom_part_types.unwrap())
-                })
-                .collect::<std::collections::HashSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>()
-                .to_numbas(locale)
-                .unwrap();
-
-            let diagnostic = Some(self.diagnostic.clone().unwrap().to_numbas(locale).unwrap());
-
-            Ok(numbas::exam::Exam {
-                basic_settings,
-                resources,
-                extensions,
-                custom_part_types,
-                navigation,
-                timing,
-                feedback,
-                functions: Some(functions.unwrap()),
-                variables: Some(variables.unwrap()),
-                question_groups,
-                diagnostic,
+        let resources: Vec<numbas::exam::Resource> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .flat_map(|qg| {
+                qg.clone()
+                    .unwrap()
+                    .questions
+                    .unwrap()
+                    .into_iter()
+                    .flat_map(|q| q.unwrap().question_data.resources.unwrap())
             })
-        } else {
-            Err(check)
+            .map(|r| r.unwrap())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .to_numbas(locale);
+
+        let extensions: Vec<String> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .flat_map(|qg| {
+                qg.clone()
+                    .unwrap()
+                    .questions
+                    .unwrap()
+                    .into_iter()
+                    .map(|q| q.unwrap().question_data.extensions.unwrap())
+            })
+            .fold(Extensions::default(), Extensions::combine)
+            .to_paths();
+
+        let custom_part_types: Vec<numbas::exam::CustomPartType> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .flat_map(|qg| {
+                qg.clone()
+                    .unwrap()
+                    .questions
+                    .unwrap()
+                    .into_iter()
+                    .flat_map(|q| q.unwrap().question_data.custom_part_types.unwrap())
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .to_numbas(locale);
+
+        let diagnostic = Some(self.diagnostic.clone().unwrap().to_numbas(locale));
+
+        numbas::exam::Exam {
+            basic_settings,
+            resources,
+            extensions,
+            custom_part_types,
+            navigation,
+            timing,
+            feedback,
+            functions: Some(functions.unwrap()),
+            variables: Some(variables.unwrap()),
+            question_groups,
+            diagnostic,
         }
     }
 }
@@ -188,35 +176,29 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for Diagnostic {
-    type NumbasType = numbas::exam::ExamDiagnostic;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            let knowledge_graph = numbas::exam::ExamDiagnosticKnowledgeGraph {
-                topics: self
-                    .topics
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|t| t.to_numbas(locale).unwrap())
-                    .collect(),
-                learning_objectives: self
-                    .objectives
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|t| t.to_numbas(locale).unwrap())
-                    .collect(),
-            };
+impl ToNumbas<numbas::exam::ExamDiagnostic> for Diagnostic {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamDiagnostic {
+        let knowledge_graph = numbas::exam::ExamDiagnosticKnowledgeGraph {
+            topics: self
+                .topics
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.to_numbas(locale))
+                .collect(),
+            learning_objectives: self
+                .objectives
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|t| t.to_numbas(locale))
+                .collect(),
+        };
 
-            Ok(Self::NumbasType {
-                knowledge_graph,
-                script: self.script.to_numbas(locale).unwrap(),
-                custom_script: self.script.clone().unwrap().to_custom_script(locale),
-            })
-        } else {
-            Err(check)
+        numbas::exam::ExamDiagnostic {
+            knowledge_graph,
+            script: self.script.to_numbas(locale),
+            custom_script: self.script.clone().unwrap().to_custom_script(locale), // TODO TONUMBAS
         }
     }
 }
@@ -239,18 +221,12 @@ pub enum DiagnosticScript {
     Custom(TranslatableString),
 }
 impl_optional_overwrite!(DiagnosticScript);
-impl ToNumbas for DiagnosticScript {
-    type NumbasType = numbas::exam::ExamDiagnosticScript;
-    fn to_numbas(&self, _locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(match self {
-                DiagnosticScript::Mastery => Self::NumbasType::Mastery,
-                DiagnosticScript::Custom(_) => Self::NumbasType::Custom,
-                DiagnosticScript::Diagnosys => Self::NumbasType::Diagnosys,
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamDiagnosticScript> for DiagnosticScript {
+    fn to_numbas(&self, _locale: &str) -> numbas::exam::ExamDiagnosticScript {
+        match self {
+            DiagnosticScript::Mastery => numbas::exam::ExamDiagnosticScript::Mastery,
+            DiagnosticScript::Custom(_) => numbas::exam::ExamDiagnosticScript::Custom,
+            DiagnosticScript::Diagnosys => numbas::exam::ExamDiagnosticScript::Diagnosys,
         }
     }
 }
@@ -287,17 +263,14 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for LearningObjective {
-    type NumbasType = numbas::exam::ExamDiagnosticKnowledgeGraphLearningObjective;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(Self::NumbasType {
-                name: self.name.clone().unwrap().to_string(locale).unwrap(),
-                description: self.description.clone().unwrap().to_string(locale).unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamDiagnosticKnowledgeGraphLearningObjective> for LearningObjective {
+    fn to_numbas(
+        &self,
+        locale: &str,
+    ) -> numbas::exam::ExamDiagnosticKnowledgeGraphLearningObjective {
+        numbas::exam::ExamDiagnosticKnowledgeGraphLearningObjective {
+            name: self.name.clone().unwrap().to_string(locale).unwrap(),
+            description: self.description.clone().unwrap().to_string(locale).unwrap(),
         }
     }
 }
@@ -325,31 +298,25 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for LearningTopic {
-    type NumbasType = numbas::exam::ExamDiagnosticKnowledgeGraphTopic;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(Self::NumbasType {
-                name: self.name.clone().unwrap().to_string(locale).unwrap(),
-                description: self.description.clone().unwrap().to_string(locale).unwrap(),
-                learning_objectives: self
-                    .objectives
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|s| s.to_string(locale).unwrap())
-                    .collect(),
-                depends_on: self
-                    .depends_on
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|s| s.to_string(locale).unwrap())
-                    .collect(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamDiagnosticKnowledgeGraphTopic> for LearningTopic {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamDiagnosticKnowledgeGraphTopic {
+        numbas::exam::ExamDiagnosticKnowledgeGraphTopic {
+            name: self.name.clone().unwrap().to_string(locale).unwrap(),
+            description: self.description.clone().unwrap().to_string(locale).unwrap(),
+            learning_objectives: self
+                .objectives
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|s| s.to_string(locale).unwrap())
+                .collect(),
+            depends_on: self
+                .depends_on
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|s| s.to_string(locale).unwrap())
+                .collect(),
         }
     }
 }

--- a/rumbas/src/data/exam.rs
+++ b/rumbas/src/data/exam.rs
@@ -3,7 +3,7 @@ use crate::data::locale::Locale;
 use crate::data::normal_exam::NormalExam;
 use crate::data::optional_overwrite::*;
 use crate::data::template::{ExamFileType, TemplateData, Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::yaml::YamlError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -21,9 +21,8 @@ optional_overwrite_enum! {
     }
 }
 
-impl ToNumbas for Exam {
-    type NumbasType = numbas::exam::Exam;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::Exam> {
+impl ToNumbas<numbas::exam::Exam> for Exam {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::Exam {
         match self {
             Exam::Normal(n) => n.to_numbas(locale),
             Exam::Diagnostic(n) => n.to_numbas(locale),

--- a/rumbas/src/data/extension.rs
+++ b/rumbas/src/data/extension.rs
@@ -7,7 +7,6 @@ use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 macro_rules! extensions {
     (

--- a/rumbas/src/data/extension.rs
+++ b/rumbas/src/data/extension.rs
@@ -2,7 +2,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_part::JMENotes;
 use crate::data::question_part::{QuestionPart, VariableReplacementStrategy};
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use schemars::JsonSchema;
@@ -28,21 +28,15 @@ macro_rules! extensions {
             }
         }
 
-        impl ToNumbas for Extensions {
-            type NumbasType = Vec<String>;
-            fn to_numbas(&self, _locale: &str) -> NumbasResult<Vec<String>> {
-                let check = self.check();
-                if check.is_empty() {
-                    let mut extensions = Vec::new();
-                    $(
-                        if self.$name.unwrap() {
-                            extensions.push($path.to_string()); //TODO: Enum in numbas crate?
-                        }
-                    )*
-                    Ok(extensions)
-                } else {
-                    Err(check)
-                }
+        impl ToNumbas<Vec<String>> for Extensions {
+            fn to_numbas(&self, _locale: &str) -> Vec<String> {
+                let mut extensions = Vec::new();
+                $(
+                    if self.$name.unwrap() {
+                        extensions.push($path.to_string()); //TODO: Enum in numbas crate?
+                    }
+                )*
+                extensions
             }
         }
 
@@ -121,16 +115,10 @@ question_part_type! {
     pub struct QuestionPartExtension {}
 }
 
-impl ToNumbas for QuestionPartExtension {
-    type NumbasType = numbas::exam::ExamQuestionPartExtension;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(Self::NumbasType {
-                part_data: self.to_numbas_shared_data(locale),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamQuestionPartExtension> for QuestionPartExtension {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartExtension {
+        numbas::exam::ExamQuestionPartExtension {
+            part_data: self.to_numbas_shared_data(locale),
         }
     }
 }

--- a/rumbas/src/data/feedback.rs
+++ b/rumbas/src/data/feedback.rs
@@ -1,6 +1,6 @@
 use crate::data::optional_overwrite::*;
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::ToRumbas;
 use crate::data::translatable::TranslatableString;
 use numbas::defaults::DEFAULTS;
@@ -26,23 +26,17 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for Feedback {
-    type NumbasType = numbas::exam::ExamFeedback;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::ExamFeedback> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::ExamFeedback {
-                show_actual_mark: self.show_current_marks.unwrap(),
-                show_total_mark: self.show_maximum_marks.unwrap(),
-                show_answer_state: self.show_answer_state.unwrap(),
-                allow_reveal_answer: self.allow_reveal_answer.unwrap(),
-                review: self.review.clone().map(|o| o.to_numbas(locale).unwrap()),
-                advice: self.advice.clone().map(|o| o.to_string(locale)).flatten(),
-                intro: self.intro.clone().unwrap().to_string(locale).unwrap(),
-                feedback_messages: self.feedback_messages.to_numbas(locale).unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamFeedback> for Feedback {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamFeedback {
+        numbas::exam::ExamFeedback {
+            show_actual_mark: self.show_current_marks.unwrap(),
+            show_total_mark: self.show_maximum_marks.unwrap(),
+            show_answer_state: self.show_answer_state.unwrap(),
+            allow_reveal_answer: self.allow_reveal_answer.unwrap(),
+            review: self.review.clone().map(|o| o.to_numbas(locale)),
+            advice: self.advice.clone().map(|o| o.to_string(locale)).flatten(),
+            intro: self.intro.clone().unwrap().to_string(locale).unwrap(),
+            feedback_messages: self.feedback_messages.to_numbas(locale),
         }
     }
 }
@@ -100,19 +94,13 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for Review {
-    type NumbasType = numbas::exam::ExamReview;
-    fn to_numbas(&self, _locale: &str) -> NumbasResult<numbas::exam::ExamReview> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::ExamReview {
-                show_score: Some(self.show_score.clone().unwrap()),
-                show_feedback: Some(self.show_feedback.clone().unwrap()),
-                show_expected_answer: Some(self.show_expected_answer.clone().unwrap()),
-                show_advice: Some(self.show_advice.clone().unwrap()),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamReview> for Review {
+    fn to_numbas(&self, _locale: &str) -> numbas::exam::ExamReview {
+        numbas::exam::ExamReview {
+            show_score: Some(self.show_score.clone().unwrap()),
+            show_feedback: Some(self.show_feedback.clone().unwrap()),
+            show_expected_answer: Some(self.show_expected_answer.clone().unwrap()),
+            show_advice: Some(self.show_advice.clone().unwrap()),
         }
     }
 }
@@ -147,12 +135,11 @@ pub struct FeedbackMessage {
 }
 impl_optional_overwrite!(FeedbackMessage);
 
-impl ToNumbas for FeedbackMessage {
-    type NumbasType = numbas::exam::ExamFeedbackMessage;
-    fn to_numbas(&self, _locale: &str) -> NumbasResult<numbas::exam::ExamFeedbackMessage> {
-        Ok(numbas::exam::ExamFeedbackMessage {
+impl ToNumbas<numbas::exam::ExamFeedbackMessage> for FeedbackMessage {
+    fn to_numbas(&self, _locale: &str) -> numbas::exam::ExamFeedbackMessage {
+        numbas::exam::ExamFeedbackMessage {
             message: self.message.clone(),
             threshold: self.threshold.clone(),
-        })
+        }
     }
 }

--- a/rumbas/src/data/file_reference.rs
+++ b/rumbas/src/data/file_reference.rs
@@ -46,7 +46,7 @@ macro_rules! file_type {
                                 Err(e) => $check_expr(e),
                             }
                         }
-                        None => RumbasCheckResult::empty(), // TODO: change
+                        None => RumbasCheckResult::from_missing(Some(locale.to_string())),
                     }
                 }
             }
@@ -57,7 +57,6 @@ macro_rules! file_type {
         }
         impl_optional_overwrite_value!($type);
 
-        //TODO: error message is not shown if no file found
         impl std::convert::From<String> for $type {
             fn from(s: String) -> Self {
                 let mut prefix = FILE_PREFIX.to_owned();
@@ -81,7 +80,6 @@ macro_rules! file_type {
                             // We only care about the ones that are 'Ok'
                             {
                                 if let Ok(entry_name) = entry.file_name().into_string() {
-                                    //println!("{}", entry_name);
                                     if entry_name.starts_with("locale-") {
                                         let locale = entry_name
                                             .splitn(2, "locale-")
@@ -90,10 +88,8 @@ macro_rules! file_type {
                                             .unwrap()
                                             .to_string();
                                         let locale_file_path = file_dir.join(entry_name).join(file_name);
-                                        //println!("{}", locale_file_path.display());
                                         if locale_file_path.exists() {
                                             if let Ok(s) = std::fs::read_to_string(&locale_file_path) {
-                                                //println!("{}", s);
                                                 if let Ok(s) = s.clone().try_into() {
                                                     translated_content.insert(
                                                         locale,

--- a/rumbas/src/data/file_reference.rs
+++ b/rumbas/src/data/file_reference.rs
@@ -217,10 +217,8 @@ macro_rules! file_type {
             pub fn get_content(&self, locale: &str) -> Option<String> {
                 if let Some(c) = self.translated_content.get(locale) {
                     Some(c.clone().into())
-                } else if let Some(c) = &self.content {
-                    Some(c.clone().into())
                 } else {
-                    None
+                    self.content.as_ref().map(|c| c.clone().into())
                 }
             }
             pub fn s(content: &str) -> $type {

--- a/rumbas/src/data/function.rs
+++ b/rumbas/src/data/function.rs
@@ -5,7 +5,6 @@ use crate::data::to_rumbas::ToRumbas;
 use crate::data::translatable::{JMETranslatableString, TranslatableString};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 optional_overwrite! {
     pub struct Function {
@@ -59,14 +58,7 @@ impl ToNumbas<numbas::exam::ExamFunctionDefinition> for FunctionDefinition {
     fn to_numbas(&self, locale: &str) -> numbas::exam::ExamFunctionDefinition {
         match self {
             FunctionDefinition::JME(c) => numbas::exam::ExamFunctionDefinition::JME {
-                definition: c
-                    .definition
-                    .clone()
-                    .unwrap()
-                    .to_string(locale)
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
+                definition: c.definition.to_numbas(locale),
             },
             FunctionDefinition::Javascript(c) => numbas::exam::ExamFunctionDefinition::Javascript {
                 definition: c.definition.clone().unwrap().to_string(locale).unwrap(),

--- a/rumbas/src/data/function.rs
+++ b/rumbas/src/data/function.rs
@@ -1,6 +1,6 @@
 use crate::data::optional_overwrite::*;
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::ToRumbas;
 use crate::data::translatable::{JMETranslatableString, TranslatableString};
 use schemars::JsonSchema;
@@ -17,24 +17,18 @@ optional_overwrite! {
 }
 impl_optional_overwrite! {(String, numbas::exam::ExamFunctionType)}
 
-impl ToNumbas for Function {
-    type NumbasType = numbas::exam::ExamFunction;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::ExamFunction> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::ExamFunction {
-                parameters: self
-                    .parameters
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|(a, b)| (a, b))
-                    .collect(),
-                output_type: self.output_type.clone().unwrap(),
-                definition: self.definition.clone().unwrap().to_numbas(&locale).unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamFunction> for Function {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamFunction {
+        numbas::exam::ExamFunction {
+            parameters: self
+                .parameters
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|(a, b)| (a, b))
+                .collect(),
+            output_type: self.output_type.clone().unwrap(),
+            definition: self.definition.clone().unwrap().to_numbas(&locale),
         }
     }
 }
@@ -61,30 +55,22 @@ optional_overwrite_enum! {
     }
 }
 
-impl ToNumbas for FunctionDefinition {
-    type NumbasType = numbas::exam::ExamFunctionDefinition;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::ExamFunctionDefinition> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(match self {
-                FunctionDefinition::JME(c) => numbas::exam::ExamFunctionDefinition::JME {
-                    definition: c
-                        .definition
-                        .clone()
-                        .unwrap()
-                        .to_string(locale)
-                        .unwrap()
-                        .try_into()
-                        .unwrap(),
-                },
-                FunctionDefinition::Javascript(c) => {
-                    numbas::exam::ExamFunctionDefinition::Javascript {
-                        definition: c.definition.clone().unwrap().to_string(locale).unwrap(),
-                    }
-                }
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamFunctionDefinition> for FunctionDefinition {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamFunctionDefinition {
+        match self {
+            FunctionDefinition::JME(c) => numbas::exam::ExamFunctionDefinition::JME {
+                definition: c
+                    .definition
+                    .clone()
+                    .unwrap()
+                    .to_string(locale)
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            },
+            FunctionDefinition::Javascript(c) => numbas::exam::ExamFunctionDefinition::Javascript {
+                definition: c.definition.clone().unwrap().to_string(locale).unwrap(),
+            },
         }
     }
 }

--- a/rumbas/src/data/gapfill.rs
+++ b/rumbas/src/data/gapfill.rs
@@ -8,7 +8,6 @@ use crate::data::translatable::ContentAreaTranslatableString;
 use numbas::defaults::DEFAULTS;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 question_part_type! {
     // The Gap fill question part type

--- a/rumbas/src/data/gapfill.rs
+++ b/rumbas/src/data/gapfill.rs
@@ -2,7 +2,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_part::JMENotes;
 use crate::data::question_part::{QuestionPart, VariableReplacementStrategy};
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use numbas::defaults::DEFAULTS;
@@ -20,24 +20,18 @@ question_part_type! {
     }
 }
 
-impl ToNumbas for QuestionPartGapFill {
-    type NumbasType = numbas::exam::ExamQuestionPartGapFill;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::ExamQuestionPartGapFill> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::ExamQuestionPartGapFill {
-                part_data: self.to_numbas_shared_data(locale),
-                sort_answers: Some(self.sort_answers.clone().unwrap()),
-                gaps: self
-                    .gaps
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|g| g.to_numbas(locale).unwrap())
-                    .collect(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamQuestionPartGapFill> for QuestionPartGapFill {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartGapFill {
+        numbas::exam::ExamQuestionPartGapFill {
+            part_data: self.to_numbas_shared_data(locale),
+            sort_answers: Some(self.sort_answers.clone().unwrap()),
+            gaps: self
+                .gaps
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|g| g.to_numbas(locale))
+                .collect(),
         }
     }
 }

--- a/rumbas/src/data/information.rs
+++ b/rumbas/src/data/information.rs
@@ -7,7 +7,6 @@ use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 question_part_type! {
     pub struct QuestionPartInformation {}

--- a/rumbas/src/data/information.rs
+++ b/rumbas/src/data/information.rs
@@ -2,7 +2,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_part::JMENotes;
 use crate::data::question_part::{QuestionPart, VariableReplacementStrategy};
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use schemars::JsonSchema;
@@ -13,16 +13,10 @@ question_part_type! {
     pub struct QuestionPartInformation {}
 }
 
-impl ToNumbas for QuestionPartInformation {
-    type NumbasType = numbas::exam::ExamQuestionPartInformation;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(Self::NumbasType {
-                part_data: self.to_numbas_shared_data(locale),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamQuestionPartInformation> for QuestionPartInformation {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartInformation {
+        numbas::exam::ExamQuestionPartInformation {
+            part_data: self.to_numbas_shared_data(locale), // TODO: to numbas?
         }
     }
 }

--- a/rumbas/src/data/jme.rs
+++ b/rumbas/src/data/jme.rs
@@ -3,7 +3,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_part::JMENotes;
 use crate::data::question_part::{QuestionPart, VariableReplacementStrategy};
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::ToRumbas;
 use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
@@ -36,80 +36,68 @@ question_part_type! {
     }
 }
 
-impl ToNumbas for QuestionPartJME {
-    type NumbasType = numbas::exam::ExamQuestionPartJME;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::ExamQuestionPartJME> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::ExamQuestionPartJME {
-                part_data: self.to_numbas_shared_data(locale),
-                answer: self
-                    .answer
+impl ToNumbas<numbas::exam::ExamQuestionPartJME> for QuestionPartJME {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartJME {
+        numbas::exam::ExamQuestionPartJME {
+            part_data: self.to_numbas_shared_data(locale),
+            answer: self
+                .answer
+                .clone()
+                .unwrap()
+                .to_string(locale)
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            answer_simplification: Some(
+                self.answer_simplification
                     .clone()
                     .unwrap()
-                    .to_string(locale)
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
-                answer_simplification: Some(
-                    self.answer_simplification
-                        .clone()
-                        .unwrap()
-                        .to_numbas(locale)
-                        .unwrap(),
-                ),
-                show_preview: self.show_preview.clone().unwrap(),
-                checking_type: self
-                    .answer_check
-                    .clone()
-                    .unwrap()
-                    .to_numbas(locale)
-                    .unwrap(),
-                failure_rate: Some(self.failure_rate.unwrap()),
-                vset_range: [
-                    self.vset_range.unwrap()[0].into(),
-                    self.vset_range.unwrap()[1].into(),
-                ],
-                vset_range_points: self.vset_range_points.unwrap().into(),
-                check_variable_names: self.check_variable_names.unwrap(),
-                single_letter_variables: Some(self.single_letter_variables.clone().unwrap()),
-                allow_unknown_functions: Some(self.allow_unknown_functions.clone().unwrap()),
-                implicit_function_composition: Some(
-                    self.implicit_function_composition.clone().unwrap(),
-                ),
-                max_length: self
-                    .max_length
-                    .clone()
-                    .map(|v| v.to_numbas(locale).unwrap())
-                    .flatten(),
-                min_length: self
-                    .min_length
-                    .clone()
-                    .map(|v| v.to_numbas(locale).unwrap())
-                    .flatten(),
-                must_have: self
-                    .must_have
-                    .clone()
-                    .map(|v| v.to_numbas(locale).unwrap())
-                    .flatten(),
-                may_not_have: self
-                    .may_not_have
-                    .clone()
-                    .map(|v| v.to_numbas(locale).unwrap())
-                    .flatten(),
-                must_match_pattern: self
-                    .must_match_pattern
-                    .clone()
-                    .map(|v| v.to_numbas(locale).unwrap())
-                    .flatten(),
-                value_generators: self
-                    .value_generators
-                    .clone()
-                    .map(|v| v.to_numbas(locale).unwrap())
-                    .flatten(),
-            })
-        } else {
-            Err(check)
+                    .to_numbas(locale),
+            ),
+            show_preview: self.show_preview.clone().unwrap(),
+            checking_type: self.answer_check.clone().unwrap().to_numbas(locale),
+            failure_rate: Some(self.failure_rate.unwrap()),
+            vset_range: [
+                self.vset_range.unwrap()[0].into(),
+                self.vset_range.unwrap()[1].into(),
+            ],
+            vset_range_points: self.vset_range_points.unwrap().into(),
+            check_variable_names: self.check_variable_names.unwrap(),
+            single_letter_variables: Some(self.single_letter_variables.clone().unwrap()),
+            allow_unknown_functions: Some(self.allow_unknown_functions.clone().unwrap()),
+            implicit_function_composition: Some(
+                self.implicit_function_composition.clone().unwrap(),
+            ),
+            max_length: self
+                .max_length
+                .clone()
+                .map(|v| v.to_numbas(locale))
+                .flatten(),
+            min_length: self
+                .min_length
+                .clone()
+                .map(|v| v.to_numbas(locale))
+                .flatten(),
+            must_have: self
+                .must_have
+                .clone()
+                .map(|v| v.to_numbas(locale))
+                .flatten(),
+            may_not_have: self
+                .may_not_have
+                .clone()
+                .map(|v| v.to_numbas(locale))
+                .flatten(),
+            must_match_pattern: self
+                .must_match_pattern
+                .clone()
+                .map(|v| v.to_numbas(locale))
+                .flatten(),
+            value_generators: self
+                .value_generators
+                .clone()
+                .map(|v| v.to_numbas(locale))
+                .flatten(),
         }
     }
 }
@@ -241,90 +229,81 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for JMEAnswerSimplification {
-    type NumbasType = Vec<numbas::exam::AnswerSimplificationType>;
-    fn to_numbas(
-        &self,
-        _locale: &str,
-    ) -> NumbasResult<Vec<numbas::exam::AnswerSimplificationType>> {
-        let check = self.check();
-        if check.is_empty() {
-            let mut v = Vec::new();
-            if self.simplify_basic.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::Basic(true));
-            }
-            if self.simplify_unit_factor.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::UnitFactor(true));
-            }
-            if self.simplify_unit_power.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::UnitPower(true));
-            }
-            if self.simplify_unit_denominator.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::UnitDenominator(
-                    true,
-                ));
-            }
-            if self.simplify_zero_factor.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::ZeroFactor(true));
-            }
-            if self.simplify_zero_term.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::ZeroTerm(true));
-            }
-            if self.simplify_zero_power.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::ZeroPower(true));
-            }
-            if self.simplify_zero_base.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::ZeroBase(true));
-            }
-            if self.collect_numbers.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::CollectNumbers(true));
-            }
-            if self.constants_first.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::ConstantsFirst(true));
-            }
-            if self.simplify_sqrt_products.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::SqrtProduct(true));
-            }
-            if self.simplify_sqrt_division.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::SqrtDivision(true));
-            }
-            if self.simplify_sqrt_square.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::SqrtSquare(true));
-            }
-            if self.simplify_other_numbers.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::OtherNumbers(true));
-            }
-            if self.simplify_no_leading_minus.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::NoLeadingMinus(true));
-            }
-            if self.simplify_fractions.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::Fractions(true));
-            }
-            if self.simplify_trigonometric.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::Trigonometric(true));
-            }
-            if self.cancel_terms.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::CancelTerms(true));
-            }
-            if self.cancel_factors.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::CancelFactors(true));
-            }
-            if self.collect_like_fractions.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::CollectLikeFractions(true));
-            }
-            if self.order_canonical.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::CanonicalOrder(true));
-            }
-            if self.use_times_dot.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::TimesDot(true));
-            }
-            if self.expand_brackets.unwrap() {
-                v.push(numbas::exam::AnswerSimplificationType::ExpandBrackets(true));
-            }
-            Ok(v)
-        } else {
-            Err(check)
+impl ToNumbas<Vec<numbas::exam::AnswerSimplificationType>> for JMEAnswerSimplification {
+    fn to_numbas(&self, _locale: &str) -> Vec<numbas::exam::AnswerSimplificationType> {
+        let mut v = Vec::new();
+        if self.simplify_basic.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::Basic(true));
         }
+        if self.simplify_unit_factor.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::UnitFactor(true));
+        }
+        if self.simplify_unit_power.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::UnitPower(true));
+        }
+        if self.simplify_unit_denominator.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::UnitDenominator(
+                true,
+            ));
+        }
+        if self.simplify_zero_factor.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::ZeroFactor(true));
+        }
+        if self.simplify_zero_term.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::ZeroTerm(true));
+        }
+        if self.simplify_zero_power.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::ZeroPower(true));
+        }
+        if self.simplify_zero_base.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::ZeroBase(true));
+        }
+        if self.collect_numbers.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::CollectNumbers(true));
+        }
+        if self.constants_first.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::ConstantsFirst(true));
+        }
+        if self.simplify_sqrt_products.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::SqrtProduct(true));
+        }
+        if self.simplify_sqrt_division.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::SqrtDivision(true));
+        }
+        if self.simplify_sqrt_square.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::SqrtSquare(true));
+        }
+        if self.simplify_other_numbers.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::OtherNumbers(true));
+        }
+        if self.simplify_no_leading_minus.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::NoLeadingMinus(true));
+        }
+        if self.simplify_fractions.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::Fractions(true));
+        }
+        if self.simplify_trigonometric.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::Trigonometric(true));
+        }
+        if self.cancel_terms.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::CancelTerms(true));
+        }
+        if self.cancel_factors.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::CancelFactors(true));
+        }
+        if self.collect_like_fractions.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::CollectLikeFractions(true));
+        }
+        if self.order_canonical.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::CanonicalOrder(true));
+        }
+        if self.use_times_dot.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::TimesDot(true));
+        }
+        if self.expand_brackets.unwrap() {
+            v.push(numbas::exam::AnswerSimplificationType::ExpandBrackets(true));
+        }
+        v
     }
 }
 
@@ -485,16 +464,15 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for CheckingTypeDataFloat {
-    type NumbasType = numbas::exam::JMECheckingTypeData<numbas::exam::SafeFloat>;
-    fn to_numbas(&self, _locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::JMECheckingTypeData {
-                checking_accuracy: self.max_difference.unwrap().into(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMECheckingTypeData<numbas::exam::SafeFloat>>
+    for CheckingTypeDataFloat
+{
+    fn to_numbas(
+        &self,
+        _locale: &str,
+    ) -> numbas::exam::JMECheckingTypeData<numbas::exam::SafeFloat> {
+        numbas::exam::JMECheckingTypeData {
+            checking_accuracy: self.max_difference.unwrap().into(),
         }
     }
 }
@@ -505,16 +483,10 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for CheckingTypeDataNatural {
-    type NumbasType = numbas::exam::JMECheckingTypeData<usize>;
-    fn to_numbas(&self, _locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::JMECheckingTypeData {
-                checking_accuracy: self.amount.unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMECheckingTypeData<usize>> for CheckingTypeDataNatural {
+    fn to_numbas(&self, _locale: &str) -> numbas::exam::JMECheckingTypeData<usize> {
+        numbas::exam::JMECheckingTypeData {
+            checking_accuracy: self.amount.unwrap(),
         }
     }
 }
@@ -530,27 +502,21 @@ pub enum CheckingType {
 }
 impl_optional_overwrite!(CheckingType);
 
-impl ToNumbas for CheckingType {
-    type NumbasType = numbas::exam::JMECheckingType;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(match self {
-                CheckingType::RelativeDifference(f) => {
-                    numbas::exam::JMECheckingType::RelativeDifference(f.to_numbas(locale).unwrap())
-                }
-                CheckingType::AbsoluteDifference(f) => {
-                    numbas::exam::JMECheckingType::AbsoluteDifference(f.to_numbas(locale).unwrap())
-                }
-                CheckingType::DecimalPlaces(f) => {
-                    numbas::exam::JMECheckingType::DecimalPlaces(f.to_numbas(locale).unwrap())
-                }
-                CheckingType::SignificantFigures(f) => {
-                    numbas::exam::JMECheckingType::SignificantFigures(f.to_numbas(locale).unwrap())
-                }
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMECheckingType> for CheckingType {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::JMECheckingType {
+        match self {
+            CheckingType::RelativeDifference(f) => {
+                numbas::exam::JMECheckingType::RelativeDifference(f.to_numbas(locale))
+            }
+            CheckingType::AbsoluteDifference(f) => {
+                numbas::exam::JMECheckingType::AbsoluteDifference(f.to_numbas(locale))
+            }
+            CheckingType::DecimalPlaces(f) => {
+                numbas::exam::JMECheckingType::DecimalPlaces(f.to_numbas(locale))
+            }
+            CheckingType::SignificantFigures(f) => {
+                numbas::exam::JMECheckingType::SignificantFigures(f.to_numbas(locale))
+            }
         }
     }
 }
@@ -590,18 +556,12 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for JMERestriction {
-    type NumbasType = numbas::exam::JMERestriction;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::JMERestriction> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::JMERestriction {
-                // name: self.name.clone().unwrap().to_string(locale).unwrap(),
-                partial_credit: self.partial_credit.clone().unwrap().into(),
-                message: self.message.clone().unwrap().to_string(locale).unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMERestriction> for JMERestriction {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::JMERestriction {
+        numbas::exam::JMERestriction {
+            // name: self.name.clone().unwrap().to_string(locale).unwrap(),
+            partial_credit: self.partial_credit.clone().unwrap().into(),
+            message: self.message.clone().unwrap().to_string(locale).unwrap(),
         }
     }
 }
@@ -624,17 +584,11 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for JMELengthRestriction {
-    type NumbasType = numbas::exam::JMELengthRestriction;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::JMELengthRestriction> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::JMELengthRestriction {
-                restriction: self.restriction.clone().unwrap().to_numbas(locale).unwrap(),
-                length: Some(self.length.clone().unwrap().into()),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMELengthRestriction> for JMELengthRestriction {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::JMELengthRestriction {
+        numbas::exam::JMELengthRestriction {
+            restriction: self.restriction.clone().unwrap().to_numbas(locale),
+            length: Some(self.length.clone().unwrap().into()),
         }
     }
 }
@@ -661,24 +615,18 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for JMEStringRestriction {
-    type NumbasType = numbas::exam::JMEStringRestriction;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::JMEStringRestriction> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::JMEStringRestriction {
-                restriction: self.restriction.clone().unwrap().to_numbas(locale).unwrap(),
-                show_strings: self.show_strings.clone().unwrap(),
-                strings: self
-                    .strings
-                    .clone()
-                    .unwrap()
-                    .into_iter()
-                    .map(|s| s.to_string(locale).unwrap())
-                    .collect(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMEStringRestriction> for JMEStringRestriction {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::JMEStringRestriction {
+        numbas::exam::JMEStringRestriction {
+            restriction: self.restriction.clone().unwrap().to_numbas(locale),
+            show_strings: self.show_strings.clone().unwrap(),
+            strings: self
+                .strings
+                .clone()
+                .unwrap()
+                .into_iter()
+                .map(|s| s.to_string(locale).unwrap())
+                .collect(),
         }
     }
 }
@@ -708,19 +656,13 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for JMEPatternRestriction {
-    type NumbasType = numbas::exam::JMEPatternRestriction;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::JMEPatternRestriction> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::JMEPatternRestriction {
-                partial_credit: self.partial_credit.clone().unwrap().into(),
-                message: self.message.clone().unwrap().to_string(locale).unwrap(),
-                pattern: self.pattern.clone().unwrap(),
-                name_to_compare: self.name_to_compare.clone().unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMEPatternRestriction> for JMEPatternRestriction {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::JMEPatternRestriction {
+        numbas::exam::JMEPatternRestriction {
+            partial_credit: self.partial_credit.clone().unwrap().into(),
+            message: self.message.clone().unwrap().to_string(locale).unwrap(),
+            pattern: self.pattern.clone().unwrap(),
+            name_to_compare: self.name_to_compare.clone().unwrap(),
         }
     }
 }
@@ -743,23 +685,15 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for JMEValueGenerator {
-    type NumbasType = numbas::exam::JMEValueGenerator;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::JMEValueGenerator> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::JMEValueGenerator {
-                name: self.name.clone().unwrap().get_content(locale),
-                value: self
-                    .value
-                    .clone()
-                    .unwrap()
-                    .get_content(locale)
-                    .try_into()
-                    .expect("invalid jme string in value of valuegenerator"),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::JMEValueGenerator> for JMEValueGenerator {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::JMEValueGenerator {
+        numbas::exam::JMEValueGenerator {
+            name: self.name.clone().unwrap().to_numbas(locale),
+            value: self
+                .value
+                .clone()
+                .unwrap()
+                .to_numbas(locale),
         }
     }
 }

--- a/rumbas/src/data/jme.rs
+++ b/rumbas/src/data/jme.rs
@@ -12,7 +12,6 @@ use crate::data::translatable::TranslatableString;
 use numbas::defaults::DEFAULTS;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 question_part_type! {
     pub struct QuestionPartJME {
@@ -40,14 +39,7 @@ impl ToNumbas<numbas::exam::ExamQuestionPartJME> for QuestionPartJME {
     fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartJME {
         numbas::exam::ExamQuestionPartJME {
             part_data: self.to_numbas_shared_data(locale),
-            answer: self
-                .answer
-                .clone()
-                .unwrap()
-                .to_string(locale)
-                .unwrap()
-                .try_into()
-                .unwrap(),
+            answer: self.answer.to_numbas(locale),
             answer_simplification: Some(
                 self.answer_simplification
                     .clone()
@@ -689,11 +681,7 @@ impl ToNumbas<numbas::exam::JMEValueGenerator> for JMEValueGenerator {
     fn to_numbas(&self, locale: &str) -> numbas::exam::JMEValueGenerator {
         numbas::exam::JMEValueGenerator {
             name: self.name.clone().unwrap().to_numbas(locale),
-            value: self
-                .value
-                .clone()
-                .unwrap()
-                .to_numbas(locale),
+            value: self.value.clone().unwrap().to_numbas(locale),
         }
     }
 }

--- a/rumbas/src/data/matrix.rs
+++ b/rumbas/src/data/matrix.rs
@@ -2,7 +2,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_part::JMENotes;
 use crate::data::question_part::{QuestionPart, VariableReplacementStrategy};
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use schemars::JsonSchema;
@@ -26,35 +26,25 @@ question_part_type! {
     }
 }
 
-impl ToNumbas for QuestionPartMatrix {
-    type NumbasType = numbas::exam::ExamQuestionPartMatrix;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            let dimensions = self.dimensions.unwrap();
-            let rows = dimensions.rows.unwrap();
-            let columns = dimensions.columns.unwrap();
-            Ok(Self::NumbasType {
-                part_data: self.to_numbas_shared_data(locale),
-                correct_answer: self.correct_answer.unwrap(),
-                correct_answer_fractions: self.display_correct_as_fraction.unwrap(),
-                num_rows: rows.default().to_numbas(locale).unwrap().map(|v| v.into()),
-                num_columns: columns
-                    .default()
-                    .to_numbas(locale)
-                    .unwrap()
-                    .map(|v| v.into()),
-                allow_resize: dimensions.is_resizable(),
-                min_columns: columns.min().to_numbas(locale).unwrap(),
-                max_columns: columns.max().to_numbas(locale).unwrap(),
-                min_rows: rows.min().to_numbas(locale).unwrap(),
-                max_rows: rows.max().to_numbas(locale).unwrap(),
-                tolerance: self.max_absolute_deviation.unwrap(),
-                mark_per_cell: self.mark_partial_by_cells.unwrap(),
-                allow_fractions: self.allow_fractions.unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamQuestionPartMatrix> for QuestionPartMatrix {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartMatrix {
+        let dimensions = self.dimensions.unwrap();
+        let rows = dimensions.rows.unwrap();
+        let columns = dimensions.columns.unwrap();
+        numbas::exam::ExamQuestionPartMatrix {
+            part_data: self.to_numbas_shared_data(locale),
+            correct_answer: self.correct_answer.unwrap(),
+            correct_answer_fractions: self.display_correct_as_fraction.unwrap(),
+            num_rows: rows.default().to_numbas(locale).map(|v| v.into()),
+            num_columns: columns.default().to_numbas(locale).map(|v| v.into()),
+            allow_resize: dimensions.is_resizable(),
+            min_columns: columns.min().to_numbas(locale),
+            max_columns: columns.max().to_numbas(locale),
+            min_rows: rows.min().to_numbas(locale),
+            max_rows: rows.max().to_numbas(locale),
+            tolerance: self.max_absolute_deviation.unwrap(),
+            mark_per_cell: self.mark_partial_by_cells.unwrap(),
+            allow_fractions: self.allow_fractions.unwrap(),
         }
     }
 }

--- a/rumbas/src/data/matrix.rs
+++ b/rumbas/src/data/matrix.rs
@@ -7,7 +7,6 @@ use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 // See https://docs.numbas.org.uk/en/latest/question/parts/matrixentry.html#matrix-entry
 question_part_type! {

--- a/rumbas/src/data/multiple_choice.rs
+++ b/rumbas/src/data/multiple_choice.rs
@@ -11,7 +11,6 @@ use numbas::defaults::DEFAULTS;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::convert::Into;
-use std::convert::TryInto;
 
 //TODO: defaults
 question_part_type! {

--- a/rumbas/src/data/normal_exam.rs
+++ b/rumbas/src/data/normal_exam.rs
@@ -7,7 +7,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_group::QuestionGroup;
 use crate::data::template::{Value, ValueType};
 use crate::data::timing::Timing;
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::translatable::TranslatableString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -34,138 +34,126 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for NormalExam {
-    type NumbasType = numbas::exam::Exam;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::Exam> {
-        let check = self.check();
-        if check.is_empty() {
-            let basic_settings = numbas::exam::BasicExamSettings {
-                name: self.name.clone().unwrap().to_string(locale).unwrap(), //TODO: might fail, not checked
-                duration_in_seconds: self
-                    .timing
+impl ToNumbas<numbas::exam::Exam> for NormalExam {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::Exam {
+        let basic_settings = numbas::exam::BasicExamSettings {
+            name: self.name.clone().unwrap().to_string(locale).unwrap(), //TODO: might fail, not checked
+            duration_in_seconds: self
+                .timing
+                .clone()
+                .unwrap()
+                .duration_in_seconds
+                .to_numbas(locale),
+            percentage_needed_to_pass: self
+                .feedback
+                .clone()
+                .unwrap()
+                .percentage_needed_to_pass
+                .to_numbas(locale),
+            show_question_group_names: Some(
+                self.navigation
                     .clone()
                     .unwrap()
-                    .duration_in_seconds
-                    .to_numbas(locale)
+                    .to_shared_data()
+                    .show_names_of_question_groups
                     .unwrap(),
-                percentage_needed_to_pass: self
-                    .feedback
+            ),
+            show_student_name: Some(self.feedback.clone().unwrap().show_name_of_student.unwrap()),
+            allow_printing: Some(
+                self.navigation
                     .clone()
                     .unwrap()
-                    .percentage_needed_to_pass
-                    .to_numbas(locale)
+                    .to_shared_data()
+                    .allow_printing
                     .unwrap(),
-                show_question_group_names: Some(
-                    self.navigation
-                        .clone()
-                        .unwrap()
-                        .to_shared_data()
-                        .show_names_of_question_groups
-                        .unwrap(),
-                ),
-                show_student_name: Some(
-                    self.feedback.clone().unwrap().show_name_of_student.unwrap(),
-                ),
-                allow_printing: Some(
-                    self.navigation
-                        .clone()
-                        .unwrap()
-                        .to_shared_data()
-                        .allow_printing
-                        .unwrap(),
-                ),
-            };
+            ),
+        };
 
-            let navigation = self.navigation.clone().unwrap().to_numbas(locale).unwrap();
+        let navigation = self.navigation.clone().unwrap().to_numbas(locale);
 
-            let timing = self.timing.clone().unwrap().to_numbas(locale).unwrap();
+        let timing = self.timing.clone().unwrap().to_numbas(locale);
 
-            let feedback = self.feedback.clone().unwrap().to_numbas(locale).unwrap();
+        let feedback = self.feedback.clone().unwrap().to_numbas(locale);
 
-            //TODO
-            let functions = Value::Normal(HashMap::new());
+        //TODO
+        let functions = Value::Normal(HashMap::new());
 
-            //TODO
-            let variables = Value::Normal(HashMap::new());
+        //TODO
+        let variables = Value::Normal(HashMap::new());
 
-            let question_groups: Vec<numbas::exam::ExamQuestionGroup> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .map(|qg| qg.clone().to_numbas(locale).unwrap())
-                .collect();
+        let question_groups: Vec<numbas::exam::ExamQuestionGroup> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .map(|qg| qg.clone().to_numbas(locale))
+            .collect();
 
-            let resources: Vec<numbas::exam::Resource> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .flat_map(|qg| {
-                    qg.clone()
-                        .unwrap()
-                        .questions
-                        .unwrap()
-                        .into_iter()
-                        .flat_map(|q| q.unwrap().question_data.resources.unwrap())
-                })
-                .map(|r| r.unwrap())
-                .collect::<std::collections::HashSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>()
-                .to_numbas(locale)
-                .unwrap();
-
-            let extensions: Vec<String> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .flat_map(|qg| {
-                    qg.clone()
-                        .unwrap()
-                        .questions
-                        .unwrap()
-                        .into_iter()
-                        .map(|q| q.unwrap().question_data.extensions.unwrap())
-                })
-                .fold(Extensions::default(), Extensions::combine)
-                .to_paths();
-
-            let custom_part_types: Vec<numbas::exam::CustomPartType> = self
-                .question_groups
-                .clone()
-                .unwrap()
-                .iter()
-                .flat_map(|qg| {
-                    qg.clone()
-                        .unwrap()
-                        .questions
-                        .unwrap()
-                        .into_iter()
-                        .flat_map(|q| q.unwrap().question_data.custom_part_types.unwrap())
-                })
-                .collect::<std::collections::HashSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>()
-                .to_numbas(locale)
-                .unwrap();
-
-            Ok(numbas::exam::Exam {
-                basic_settings,
-                resources,
-                extensions,
-                custom_part_types,
-                navigation,
-                timing,
-                feedback,
-                functions: Some(functions.unwrap()),
-                variables: Some(variables.unwrap()),
-                question_groups,
-                diagnostic: None,
+        let resources: Vec<numbas::exam::Resource> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .flat_map(|qg| {
+                qg.clone()
+                    .unwrap()
+                    .questions
+                    .unwrap()
+                    .into_iter()
+                    .flat_map(|q| q.unwrap().question_data.resources.unwrap())
             })
-        } else {
-            Err(check)
+            .map(|r| r.unwrap())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .to_numbas(locale);
+
+        let extensions: Vec<String> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .flat_map(|qg| {
+                qg.clone()
+                    .unwrap()
+                    .questions
+                    .unwrap()
+                    .into_iter()
+                    .map(|q| q.unwrap().question_data.extensions.unwrap())
+            })
+            .fold(Extensions::default(), Extensions::combine)
+            .to_paths();
+
+        let custom_part_types: Vec<numbas::exam::CustomPartType> = self
+            .question_groups
+            .clone()
+            .unwrap()
+            .iter()
+            .flat_map(|qg| {
+                qg.clone()
+                    .unwrap()
+                    .questions
+                    .unwrap()
+                    .into_iter()
+                    .flat_map(|q| q.unwrap().question_data.custom_part_types.unwrap())
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .to_numbas(locale);
+
+        numbas::exam::Exam {
+            basic_settings,
+            resources,
+            extensions,
+            custom_part_types,
+            navigation,
+            timing,
+            feedback,
+            functions: Some(functions.unwrap()),
+            variables: Some(variables.unwrap()),
+            question_groups,
+            diagnostic: None,
         }
     }
 }

--- a/rumbas/src/data/number_entry.rs
+++ b/rumbas/src/data/number_entry.rs
@@ -3,7 +3,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_part::JMENotes;
 use crate::data::question_part::{QuestionPart, VariableReplacementStrategy};
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use numbas::defaults::DEFAULTS;
@@ -30,41 +30,35 @@ question_part_type! {
 }
 impl_optional_overwrite!(numbas::exam::AnswerStyle);
 
-impl ToNumbas for QuestionPartNumberEntry {
-    type NumbasType = numbas::exam::ExamQuestionPartNumberEntry;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(Self::NumbasType {
-                part_data: self.to_numbas_shared_data(locale),
-                correct_answer_fraction: self.display_correct_as_fraction.clone().unwrap(),
-                correct_answer_style: Some(
-                    self.display_correct_in_style
-                        .clone()
-                        .map(|a| a.to_numbas(locale).unwrap())
-                        .unwrap(),
-                ),
-                allow_fractions: self.allow_fractions.unwrap(),
-                notation_styles: Some(
-                    self.allowed_notation_styles
-                        .clone()
-                        .unwrap()
-                        .into_iter()
-                        .map(|a| a.to_numbas(locale).unwrap())
-                        .collect(),
-                ),
-                fractions_must_be_reduced: Some(self.fractions_must_be_reduced.clone().unwrap()),
-                partial_credit_if_fraction_not_reduced: Some(
-                    self.partial_credit_if_fraction_not_reduced.clone().unwrap(),
-                ),
-                precision: None,           //TODO
-                show_precision_hint: None, //TODO
-                show_fraction_hint: Some(self.hint_fraction.clone().unwrap()),
-                answer: self.answer.to_numbas(locale).unwrap(),
-                // checking_type: Some(numbas::exam::CheckingType::Range), //TODO
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamQuestionPartNumberEntry> for QuestionPartNumberEntry {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartNumberEntry {
+        numbas::exam::ExamQuestionPartNumberEntry {
+            part_data: self.to_numbas_shared_data(locale),
+            correct_answer_fraction: self.display_correct_as_fraction.clone().unwrap(),
+            correct_answer_style: Some(
+                self.display_correct_in_style
+                    .clone()
+                    .map(|a| a.to_numbas(locale))
+                    .unwrap(),
+            ),
+            allow_fractions: self.allow_fractions.unwrap(),
+            notation_styles: Some(
+                self.allowed_notation_styles
+                    .clone()
+                    .unwrap()
+                    .into_iter()
+                    .map(|a| a.to_numbas(locale))
+                    .collect(),
+            ),
+            fractions_must_be_reduced: Some(self.fractions_must_be_reduced.clone().unwrap()),
+            partial_credit_if_fraction_not_reduced: Some(
+                self.partial_credit_if_fraction_not_reduced.clone().unwrap(),
+            ),
+            precision: None,           //TODO
+            show_precision_hint: None, //TODO
+            show_fraction_hint: Some(self.hint_fraction.clone().unwrap()),
+            answer: self.answer.to_numbas(locale),
+            // checking_type: Some(numbas::exam::CheckingType::Range), //TODO
         }
     }
 }
@@ -142,18 +136,17 @@ pub enum NumberEntryAnswer {
 }
 impl_optional_overwrite!(NumberEntryAnswer);
 
-impl ToNumbas for NumberEntryAnswer {
-    type NumbasType = numbas::exam::NumberEntryAnswerType;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        Ok(match self {
+impl ToNumbas<numbas::exam::NumberEntryAnswerType> for NumberEntryAnswer {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::NumberEntryAnswerType {
+        match self {
             NumberEntryAnswer::Normal(f) => numbas::exam::NumberEntryAnswerType::Answer {
-                answer: numbas::exam::Primitive::String(f.get_content(locale)),
+                answer: numbas::exam::Primitive::String(f.to_numbas(locale)),
             },
             NumberEntryAnswer::Range { from, to } => numbas::exam::NumberEntryAnswerType::MinMax {
-                min_value: numbas::exam::Primitive::String(from.get_content(locale)),
-                max_value: numbas::exam::Primitive::String(to.get_content(locale)),
+                min_value: numbas::exam::Primitive::String(from.to_numbas(locale)),
+                max_value: numbas::exam::Primitive::String(to.to_numbas(locale)),
             },
-        })
+        }
     }
 }
 
@@ -206,10 +199,9 @@ pub enum AnswerStyle {
 }
 impl_optional_overwrite!(AnswerStyle);
 
-impl ToNumbas for AnswerStyle {
-    type NumbasType = numbas::exam::AnswerStyle;
-    fn to_numbas(&self, _locale: &str) -> NumbasResult<Self::NumbasType> {
-        Ok(match self {
+impl ToNumbas<numbas::exam::AnswerStyle> for AnswerStyle {
+    fn to_numbas(&self, _locale: &str) -> numbas::exam::AnswerStyle {
+        match self {
             AnswerStyle::English => numbas::exam::AnswerStyle::English,
             AnswerStyle::EnglishPlain => numbas::exam::AnswerStyle::EnglishPlain,
             AnswerStyle::EnglishSI => numbas::exam::AnswerStyle::EnglishSI,
@@ -219,7 +211,7 @@ impl ToNumbas for AnswerStyle {
             AnswerStyle::Indian => numbas::exam::AnswerStyle::Indian,
             AnswerStyle::Scientific => numbas::exam::AnswerStyle::Scientific,
             AnswerStyle::Swiss => numbas::exam::AnswerStyle::Swiss,
-        })
+        }
     }
 }
 

--- a/rumbas/src/data/number_entry.rs
+++ b/rumbas/src/data/number_entry.rs
@@ -9,7 +9,6 @@ use crate::data::translatable::ContentAreaTranslatableString;
 use numbas::defaults::DEFAULTS;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 question_part_type! {
     pub struct QuestionPartNumberEntry {

--- a/rumbas/src/data/pattern_match.rs
+++ b/rumbas/src/data/pattern_match.rs
@@ -9,7 +9,6 @@ use crate::data::translatable::TranslatableString;
 use numbas::defaults::DEFAULTS;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 
 question_part_type! {
     pub struct QuestionPartPatternMatch {

--- a/rumbas/src/data/pattern_match.rs
+++ b/rumbas/src/data/pattern_match.rs
@@ -2,7 +2,7 @@ use crate::data::optional_overwrite::*;
 use crate::data::question_part::JMENotes;
 use crate::data::question_part::{QuestionPart, VariableReplacementStrategy};
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::*;
 use crate::data::translatable::ContentAreaTranslatableString;
 use crate::data::translatable::TranslatableString;
@@ -22,29 +22,23 @@ question_part_type! {
 }
 impl_optional_overwrite!(numbas::exam::PatternMatchMode);
 
-impl ToNumbas for QuestionPartPatternMatch {
-    type NumbasType = numbas::exam::ExamQuestionPartPatternMatch;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(Self::NumbasType {
-                part_data: self.to_numbas_shared_data(locale),
-                case_sensitive: Some(self.case_sensitive.unwrap()),
-                partial_credit: Some(self.partial_credit.unwrap().into()),
-                answer: numbas::exam::Primitive::String(
-                    self.pattern.clone().unwrap().to_string(locale).unwrap(),
-                ),
-                display_answer: Some(numbas::exam::Primitive::String(
-                    self.display_answer
-                        .clone()
-                        .unwrap()
-                        .to_string(locale)
-                        .unwrap(),
-                )),
-                match_mode: self.match_mode.unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamQuestionPartPatternMatch> for QuestionPartPatternMatch {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamQuestionPartPatternMatch {
+        numbas::exam::ExamQuestionPartPatternMatch {
+            part_data: self.to_numbas_shared_data(locale),
+            case_sensitive: Some(self.case_sensitive.unwrap()),
+            partial_credit: Some(self.partial_credit.unwrap().into()),
+            answer: numbas::exam::Primitive::String(
+                self.pattern.clone().unwrap().to_string(locale).unwrap(),
+            ),
+            display_answer: Some(numbas::exam::Primitive::String(
+                self.display_answer
+                    .clone()
+                    .unwrap()
+                    .to_string(locale)
+                    .unwrap(),
+            )),
+            match_mode: self.match_mode.unwrap(),
         }
     }
 }

--- a/rumbas/src/data/preamble.rs
+++ b/rumbas/src/data/preamble.rs
@@ -1,7 +1,7 @@
 use crate::data::file_reference::FileString;
 use crate::data::optional_overwrite::*;
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -15,17 +15,11 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for Preamble {
-    type NumbasType = numbas::exam::Preamble;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::Preamble> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::Preamble {
-                js: self.js.clone().unwrap().get_content(locale),
-                css: self.css.clone().unwrap().get_content(locale),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::Preamble> for Preamble {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::Preamble {
+        numbas::exam::Preamble {
+            js: self.js.clone().unwrap().to_numbas(locale),
+            css: self.css.clone().unwrap().to_numbas(locale),
         }
     }
 }

--- a/rumbas/src/data/question.rs
+++ b/rumbas/src/data/question.rs
@@ -20,7 +20,6 @@ use numbas::jme::JMEString;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fs;
 use std::path::Path;
 
@@ -66,22 +65,8 @@ impl ToNumbas<numbas::exam::ExamQuestion> for Question {
         }
         numbas::exam::ExamQuestion {
             name,
-            statement: self
-                .statement
-                .clone()
-                .unwrap()
-                .to_string(locale)
-                .unwrap()
-                .try_into()
-                .unwrap(),
-            advice: self
-                .advice
-                .clone()
-                .unwrap()
-                .to_string(locale)
-                .unwrap()
-                .try_into()
-                .unwrap(),
+            statement: self.statement.to_numbas(locale),
+            advice: self.advice.to_numbas(locale),
             parts: self
                 .parts
                 .clone()

--- a/rumbas/src/data/question_part.rs
+++ b/rumbas/src/data/question_part.rs
@@ -264,13 +264,7 @@ impl ToNumbas<numbas::exam::CustomPartMarkingNote> for JMENote {
     fn to_numbas(&self, locale: &str) -> numbas::exam::CustomPartMarkingNote {
         numbas::exam::CustomPartMarkingNote {
             name: self.name.unwrap(),
-            definition: self
-                .expression
-                .unwrap()
-                .to_string(&locale)
-                .unwrap()
-                .try_into()
-                .unwrap(),
+            definition: self.expression.to_numbas(&locale),
             description: self.description.unwrap().unwrap_or("".to_string()),
         }
     }
@@ -326,7 +320,7 @@ macro_rules! question_part_type {
             fn to_numbas_shared_data(&self, locale: &str) -> numbas::exam::ExamQuestionPartSharedData {
                 numbas::exam::ExamQuestionPartSharedData {
                     marks: Some(self.marks.clone().unwrap().into()),
-                    prompt: self.prompt.clone().map(|s| s.to_string(&locale).unwrap().try_into().unwrap()),
+                    prompt: self.prompt.clone().map(|a| a.to_numbas(locale)),
                     use_custom_name: Some(self.use_custom_name.clone().unwrap()),
                     custom_name: Some(self.custom_name.clone().unwrap()),
                     steps_penalty: Some(self.steps_penalty.clone().unwrap()),

--- a/rumbas/src/data/resource.rs
+++ b/rumbas/src/data/resource.rs
@@ -2,7 +2,7 @@ use crate::data::optional_overwrite::{
     Noneable, OptionalOverwrite, RumbasCheck, RumbasCheckResult,
 };
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::ToRumbas;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -41,23 +41,17 @@ impl std::convert::From<ResourcePath> for String {
     }
 }
 
-impl ToNumbas for ResourcePath {
-    type NumbasType = numbas::exam::Resource;
-    fn to_numbas(&self, _locale: &str) -> NumbasResult<Self::NumbasType> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::Resource([
-                self.resource_name.clone(),
-                self.resource_path
-                    .canonicalize()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-            ]))
-        } else {
-            Err(check)
-        }
+impl ToNumbas<numbas::exam::Resource> for ResourcePath {
+    fn to_numbas(&self, _locale: &str) -> numbas::exam::Resource {
+        numbas::exam::Resource([
+            self.resource_name.clone(),
+            self.resource_path
+                .canonicalize()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string(),
+        ])
     }
 }
 

--- a/rumbas/src/data/template.rs
+++ b/rumbas/src/data/template.rs
@@ -71,7 +71,7 @@ pub struct TemplateString {
     pub error_message: Option<String>,
 }
 impl RumbasCheck for TemplateString {
-    fn check(&self) -> RumbasCheckResult {
+    fn check(&self, _locale: &str) -> RumbasCheckResult {
         if let Some(e) = &self.error_message {
             RumbasCheckResult::from_missing(Some(e.clone())) // TODO: seperate missing files? (also see FileString)
         } else {

--- a/rumbas/src/data/timing.rs
+++ b/rumbas/src/data/timing.rs
@@ -1,6 +1,6 @@
 use crate::data::optional_overwrite::*;
 use crate::data::template::{Value, ValueType};
-use crate::data::to_numbas::{NumbasResult, ToNumbas};
+use crate::data::to_numbas::ToNumbas;
 use crate::data::to_rumbas::ToRumbas;
 use crate::data::translatable::TranslatableString;
 use schemars::JsonSchema;
@@ -17,23 +17,12 @@ optional_overwrite! {
     }
 }
 
-impl ToNumbas for Timing {
-    type NumbasType = numbas::exam::ExamTiming;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<numbas::exam::ExamTiming> {
-        let check = self.check();
-        if check.is_empty() {
-            Ok(numbas::exam::ExamTiming {
-                allow_pause: self.allow_pause.unwrap(),
-                timeout: self.on_timeout.clone().unwrap().to_numbas(locale).unwrap(),
-                timed_warning: self
-                    .timed_warning
-                    .clone()
-                    .unwrap()
-                    .to_numbas(locale)
-                    .unwrap(),
-            })
-        } else {
-            Err(check)
+impl ToNumbas<numbas::exam::ExamTiming> for Timing {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamTiming {
+        numbas::exam::ExamTiming {
+            allow_pause: self.allow_pause.unwrap(),
+            timeout: self.on_timeout.clone().unwrap().to_numbas(locale),
+            timed_warning: self.timed_warning.clone().unwrap().to_numbas(locale),
         }
     }
 }
@@ -63,17 +52,16 @@ pub enum TimeoutAction {
 }
 impl_optional_overwrite!(TimeoutAction);
 
-impl ToNumbas for TimeoutAction {
-    type NumbasType = numbas::exam::ExamTimeoutAction;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
-        Ok(match self {
+impl ToNumbas<numbas::exam::ExamTimeoutAction> for TimeoutAction {
+    fn to_numbas(&self, locale: &str) -> numbas::exam::ExamTimeoutAction {
+        match self {
             TimeoutAction::None => numbas::exam::ExamTimeoutAction::None {
                 message: "".to_string(), // message doesn't mean anything
             },
             TimeoutAction::Warn { message } => numbas::exam::ExamTimeoutAction::Warn {
                 message: message.to_string(locale).unwrap(),
             },
-        })
+        }
     }
 }
 

--- a/rumbas/src/data/to_numbas.rs
+++ b/rumbas/src/data/to_numbas.rs
@@ -3,46 +3,60 @@ use crate::data::template::{Value, ValueType};
 
 pub type NumbasResult<T> = Result<T, RumbasCheckResult>;
 
-pub trait ToNumbas: Clone {
-    type NumbasType;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType>;
-    fn to_numbas_with_name(&self, locale: &str, _name: String) -> NumbasResult<Self::NumbasType> {
+pub trait ToNumbas<NumbasType>: Clone + RumbasCheck {
+    /// Method that safely converts a type to another (probably numbas) type
+    fn to_numbas_safe(&self, locale: &str) -> NumbasResult<NumbasType> {
+        let check = self.check(locale);
+        if check.is_empty() {
+            Ok(self.to_numbas(locale))
+        } else {
+            Err(check)
+        }
+    }
+    /// Method that converts a type to another type
+    /// This method assumes that it is called by a function that is initially called from `to_numbas_safe`
+    fn to_numbas(&self, locale: &str) -> NumbasType;
+    fn to_numbas_with_name(&self, locale: &str, _name: String) -> NumbasType {
         self.to_numbas(locale)
     }
 }
 
-impl<T: ToNumbas + RumbasCheck> ToNumbas for Value<T> {
-    type NumbasType = <T as ToNumbas>::NumbasType;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
+impl<T: RumbasCheck> RumbasCheck for Value<T> {
+    fn check(&self, locale: &str) -> RumbasCheckResult {
         match &self.0 {
-            Some(ValueType::Normal(val)) => {
-                let check = val.check();
-                if check.is_empty() {
-                    Ok(val.to_numbas(locale).unwrap())
-                } else {
-                    Err(check)
-                }
-            }
-            Some(ValueType::Template(ts)) => Err(RumbasCheckResult::from_missing(Some(ts.yaml()))),
-            Some(ValueType::Invalid(v)) => Err(RumbasCheckResult::from_invalid(v)),
-            None => Err(RumbasCheckResult::from_missing(None)),
+            Some(ValueType::Normal(val)) => val.check(locale),
+            Some(ValueType::Template(ts)) => RumbasCheckResult::from_missing(Some(ts.yaml())),
+            Some(ValueType::Invalid(v)) => RumbasCheckResult::from_invalid(v),
+            None => RumbasCheckResult::from_missing(None),
         }
     }
 }
 
-impl<T: ToNumbas + RumbasCheck> ToNumbas for Noneable<T> {
-    type NumbasType = Option<<T as ToNumbas>::NumbasType>;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
+impl<S, T: ToNumbas<S> + RumbasCheck> ToNumbas<S> for Value<T> {
+    fn to_numbas(&self, locale: &str) -> S {
+        match &self.0 {
+            Some(ValueType::Normal(val)) => val.to_numbas(locale),
+            Some(ValueType::Template(_ts)) => unreachable!(),
+            Some(ValueType::Invalid(_v)) => unreachable!(),
+            None => unreachable!(),
+        }
+    }
+}
+
+impl<T: RumbasCheck> RumbasCheck for Noneable<T> {
+    fn check(&self, locale: &str) -> RumbasCheckResult {
         match self {
-            Noneable::NotNone(val) => {
-                let check = val.check();
-                if check.is_empty() {
-                    Ok(Some(val.clone().to_numbas(locale).unwrap()))
-                } else {
-                    Err(check)
-                }
-            }
-            _ => Ok(None),
+            Noneable::NotNone(val) => val.check(locale),
+            _ => RumbasCheckResult::empty(),
+        }
+    }
+}
+
+impl<S, T: ToNumbas<S> + RumbasCheck> ToNumbas<Option<S>> for Noneable<T> {
+    fn to_numbas(&self, locale: &str) -> Option<S> {
+        match self {
+            Noneable::NotNone(val) => Some(val.clone().to_numbas(locale)),
+            _ => None,
         }
     }
 }
@@ -50,10 +64,14 @@ impl<T: ToNumbas + RumbasCheck> ToNumbas for Noneable<T> {
 macro_rules! impl_to_numbas {
     ($($type: ty), *) => {
         $(
-        impl ToNumbas for $type {
-            type NumbasType = $type;
-            fn to_numbas(&self, _locale: &str) -> NumbasResult<Self::NumbasType> {
-                Ok(self.clone())
+        /*impl RumbasCheck for $type {
+            fn check(&self, _locale: &str) -> RumbasCheckResult {
+                RumbasCheckResult::empty()
+            }
+        }*/
+        impl ToNumbas<$type> for $type {
+            fn to_numbas(&self, _locale: &str) -> $type {
+                self.clone()
             }
         }
         )*
@@ -62,13 +80,12 @@ macro_rules! impl_to_numbas {
 
 impl_to_numbas!(String, bool, f64, usize, [f64; 2]);
 
-impl<O: ToNumbas> ToNumbas for Vec<O> {
-    type NumbasType = Vec<O::NumbasType>;
-    fn to_numbas(&self, locale: &str) -> NumbasResult<Self::NumbasType> {
+impl<S, O: ToNumbas<S>> ToNumbas<Vec<S>> for Vec<O> {
+    fn to_numbas(&self, locale: &str) -> Vec<S> {
         let mut v = Vec::new();
         for item in self.iter() {
-            v.push(item.to_numbas(locale)?);
+            v.push(item.to_numbas(locale));
         }
-        Ok(v)
+        v
     }
 }

--- a/rumbas/src/data/to_numbas.rs
+++ b/rumbas/src/data/to_numbas.rs
@@ -64,11 +64,6 @@ impl<S, T: ToNumbas<S> + RumbasCheck> ToNumbas<Option<S>> for Noneable<T> {
 macro_rules! impl_to_numbas {
     ($($type: ty), *) => {
         $(
-        /*impl RumbasCheck for $type {
-            fn check(&self, _locale: &str) -> RumbasCheckResult {
-                RumbasCheckResult::empty()
-            }
-        }*/
         impl ToNumbas<$type> for $type {
             fn to_numbas(&self, _locale: &str) -> $type {
                 self.clone()

--- a/rumbas/src/data/translatable.rs
+++ b/rumbas/src/data/translatable.rs
@@ -37,22 +37,6 @@ macro_rules! translatable_type {
 
         impl RumbasCheck for $type {
             fn check(&self, locale: &str) -> RumbasCheckResult {
-                /*let check_result =
-                match self {
-                    $type::Translated(m) => {
-                        let mut empty = RumbasCheckResult::empty();
-                        for (k, v) in m.iter() {
-                            let mut new = v.check(locale);
-                            new.extend_path(k.to_owned());
-                            empty.union(&new);
-                        }
-                        empty
-                    }
-                    $type::NotTranslated(f) => RumbasCheckResult::empty(), // don't validate FileStrings (they assume complete JME etc in the string)
-                };
-                if !check_result.is_empty() {
-                    check_result
-                } else {*/
                 let content = self.to_string(locale);
                 match content {
                     Some(c) => {
@@ -64,7 +48,6 @@ macro_rules! translatable_type {
                     }
                     None => RumbasCheckResult::empty(), // TODO: change
                 }
-                //}
             }
         }
 

--- a/rumbas/src/data/translatable.rs
+++ b/rumbas/src/data/translatable.rs
@@ -46,7 +46,7 @@ macro_rules! translatable_type {
                             Err(e) => $check_expr(e),
                         }
                     }
-                    None => RumbasCheckResult::empty(), // TODO: change
+                    None => RumbasCheckResult::from_missing(Some(locale.to_owned())),
                 }
             }
         }
@@ -118,7 +118,7 @@ macro_rules! translatable_type {
                                 }
                             })
                             .flatten()
-                    } //TODO content to static string //TODO: check for missing translations
+                    } //TODO content to static string
                 }
             }
         }


### PR DESCRIPTION
- Refactor of ToNumbas: check for RumbasCheckResult errors only in a default implementation and fix Translatable jme strings
- Improve cli
  - Prettier rumbas check error logging
  - Compile other locales when one fails 