### PR TITLE
Minify

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,7 +112,7 @@ jobs:
           git clone https://github.com/numbas/numbas-extension-stats.git ~/NUMBAS/extensions/stats
           git clone https://github.com/numbas/numbas-extension-eukleides.git ~/NUMBAS/extensions/eukleides
           git clone https://github.com/numbas/numbas-extension-geogebra.git ~/NUMBAS/extensions/geogebra # TODO: build the right js files?
-          git clone https://github.com/jhoobergs/numbas-extension-random-person.git ~/NUMBAS/extensions/random_person 
+          git clone https://github.com/jhoobergs/numbas-extension-random-person.git ~/NUMBAS/extensions/random_person_git 
           git clone https://github.com/numbas/numbas-extension-download-a-text-file.git ~/NUMBAS/extensions/download-text-file 
           git clone https://github.com/numbas/numbas-extension-codewords.git ~/NUMBAS/extensions/codewords 
           git clone https://github.com/numbas/numbas-extension-permutations.git ~/NUMBAS/extensions/permutations 
@@ -124,7 +124,8 @@ jobs:
           cp -r extensions/written_number ~/NUMBAS/extensions/written-number
           cp -r extensions/graphs ~/NUMBAS/extensions/graphs
           cd ~/NUMBAS && pip install -r requirements.txt
-          cd ~/NUMBAS/extensions/random_person && git checkout prefix_compression
+          cd ~/NUMBAS/extensions/random_person_git && git checkout prefix_compression
+          mkdir ~/NUMBAS/extensions/random_person && cp ~/NUMBAS/extensions/random_person_git/random_person.js ~/NUMBAS/extensions/random_person
       - name: Run cli-tests
         run: |-
           export NUMBAS_FOLDER=~/NUMBAS

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,13 @@ jobs:
             rumbas_support/target
             rumbas_support_derive/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install minifyers
+        run: |-
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+          sudo apt update && sudo apt install yarn
+          yarn global add uglify-js
+          yarn global add uglifycss
       - name: Install rumbas
         run: cargo install --path .
         working-directory: rumbas

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,7 +125,7 @@ jobs:
           cp -r extensions/graphs ~/NUMBAS/extensions/graphs
           cd ~/NUMBAS && pip install -r requirements.txt
           cd ~/NUMBAS/extensions/random_person_git && git checkout prefix_compression
-          mkdir ~/NUMBAS/extensions/random_person && cp ~/NUMBAS/extensions/random_person_git/random_person.js ~/NUMBAS/extensions/random_person
+          mkdir ~/NUMBAS/extensions/random_person && cp ~/NUMBAS/extensions/random_person_git/lib/random_person.js ~/NUMBAS/extensions/random_person
       - name: Run cli-tests
         run: |-
           export NUMBAS_FOLDER=~/NUMBAS

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,7 +112,7 @@ jobs:
           git clone https://github.com/numbas/numbas-extension-stats.git ~/NUMBAS/extensions/stats
           git clone https://github.com/numbas/numbas-extension-eukleides.git ~/NUMBAS/extensions/eukleides
           git clone https://github.com/numbas/numbas-extension-geogebra.git ~/NUMBAS/extensions/geogebra # TODO: build the right js files?
-          git clone https://github.com/numbas/numbas-extension-random-person.git ~/NUMBAS/extensions/random_person 
+          git clone https://github.com/jhoobergs/numbas-extension-random-person.git ~/NUMBAS/extensions/random_person 
           git clone https://github.com/numbas/numbas-extension-download-a-text-file.git ~/NUMBAS/extensions/download-text-file 
           git clone https://github.com/numbas/numbas-extension-codewords.git ~/NUMBAS/extensions/codewords 
           git clone https://github.com/numbas/numbas-extension-permutations.git ~/NUMBAS/extensions/permutations 
@@ -124,6 +124,7 @@ jobs:
           cp -r extensions/written_number ~/NUMBAS/extensions/written-number
           cp -r extensions/graphs ~/NUMBAS/extensions/graphs
           cd ~/NUMBAS && pip install -r requirements.txt
+          cd ~/NUMBAS/extensions/random_person && git checkout prefix_compression
       - name: Run cli-tests
         run: |-
           export NUMBAS_FOLDER=~/NUMBAS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `answer_display` field to `jme` part type.
 - Sqlite extension
+- `--no-minification` flag for `compile` command to suppress the `js` and `css` minification of Numbas. Before this addition, minification was not performed, now it is enabled by default.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed fields of `JMEAnswerSimplification`:
   - The new names should be much more clear
   - The old names are still valid
+- Dockerfile: updated numbas version (so minify_css is supported)
 
 ## [0.4.0] - 2021-08-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN git clone https://github.com/numbas/Numbas.git Numbas
 
 WORKDIR /usr/app/Numbas
 RUN git fetch && git checkout 7fb4fd4a24410316c36c3f140227fe240c5207a3
+RUN rm -r docs .git tests # remove large folders
 
 # Fetch jsx graph extension
 FROM alpine as jsxgraph_fetcher
@@ -47,6 +48,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-jsxgraph.git jsxgraph
 WORKDIR /usr/app/jsxgraph
 RUN git fetch && git checkout 9bc865f695009cf1942060be4e725e3dc687895b 
+RUN rm -r .git # remove large folders
 
 # Fetch stats extension
 FROM alpine as stats_fetcher
@@ -55,6 +57,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-stats.git stats
 WORKDIR /usr/app/stats
 RUN git fetch && git checkout 62ed29f8ef06dafef7b9fc47dc843d668e119966
+RUN rm -r .git # remove large folders
 
 # Fetch euklides extension
 FROM alpine as eukleides_fetcher
@@ -63,6 +66,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-eukleides.git eukleides
 WORKDIR /usr/app/eukleides
 RUN git fetch && git checkout bac3d060cd70d79fb6f897f0a54076ec916b8e14
+RUN rm -r .git # remove large folders
 
 # Fetch geogebra extension
 FROM alpine as geogebra_fetcher
@@ -71,6 +75,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-geogebra.git geogebra
 WORKDIR /usr/app/geogebra
 RUN git fetch && git checkout 14fdb023341357134b6376f5f6084834587d6f8f
+RUN rm -r .git # remove large folders
 
 # Fetch random_person extension
 FROM alpine as random_person_fetcher
@@ -79,6 +84,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-random-person.git random_person
 WORKDIR /usr/app/random_person
 RUN git fetch && git checkout 4031704f9570b0ad8a6918a0dc1e8063220392a8
+RUN rm -r .git datasets # remove large folders
 
 # Fetch download_text_file extension
 FROM alpine as download_text_file_fetcher
@@ -87,6 +93,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-download-a-text-file.git download-text-file
 WORKDIR /usr/app/download-text-file
 RUN git fetch && git checkout 32b99089a6d9837565a183e70f13d6351db61782
+RUN rm -r .git # remove large folders
 
 # Fetch codewords (linear codes) extension
 FROM alpine as codewords_fetcher
@@ -95,6 +102,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-codewords.git codewords
 WORKDIR /usr/app/codewords
 RUN git fetch && git checkout 24b82c6d57027d33fffb8a58493174743d202d41
+RUN rm -r .git # remove large folders
 
 # Fetch permutations extension
 FROM alpine as permutations_fetcher
@@ -103,6 +111,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-permutations.git permutations
 WORKDIR /usr/app/permutations
 RUN git fetch && git checkout 9b6b7a44c6b7dcbf03b1a7ffd03ed383194da721
+RUN rm -r .git # remove large folders
 
 # Fetch quantities extension
 FROM alpine as quantities_fetcher
@@ -111,6 +120,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-quantities.git quantities
 WORKDIR /usr/app/quantities
 RUN git fetch && git checkout 05fa4bba4bbac078747c6dab2600496036a82857
+RUN rm -r .git # remove large folders
 
 # Fetch optimisation extension
 FROM alpine as optimisation_fetcher
@@ -119,6 +129,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-optimisation.git optimisation
 WORKDIR /usr/app/optimisation
 RUN git fetch && git checkout 06899711367414950c7118329cb7c7c1bbb0542e
+RUN rm -r .git # remove large folders
 
 # Fetch polynomials extension
 FROM alpine as polynomials_fetcher
@@ -127,6 +138,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-polynomials.git polynomials
 WORKDIR /usr/app/polynomials
 RUN git fetch && git checkout ab321aa13dc80609393553190233d1a771d04e7c
+RUN rm -r .git # remove large folders
 
 # Fetch chemistry extension
 FROM alpine as chemistry_fetcher
@@ -135,6 +147,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-chemistry.git chemistry
 WORKDIR /usr/app/chemistry
 RUN git fetch && git checkout 6527a4690bd7ee5bca5e4f54facd8170eb018a2e
+RUN rm -r .git # remove large folders
 
 # Fetch linear-algebra extension
 FROM alpine as linear_algebra_fetcher
@@ -143,6 +156,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/numbas-extension-linearalgebra.git linear_algebra
 WORKDIR /usr/app/linear_algebra
 RUN git fetch && git checkout 09672fccdf28ea30fc9b14ad5ab7b15515d97598
+RUN rm -r .git # remove large folders
 
 # Fetch sqlite extension
 FROM alpine as sqlite_fetcher
@@ -151,6 +165,7 @@ RUN apk add git
 RUN git clone https://github.com/jhoobergs/numbas-extension-sqlite.git sqlite
 WORKDIR /usr/app/sqlite
 # TODO, when sqlite is more stable, take specific commit RUN git fetch && git checkout 09672fccdf28ea30fc9b14ad5ab7b15515d97598
+RUN rm -r .git # remove large folders
 
 # Main image
 FROM python:3.6.10-alpine 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,9 @@ RUN rm -r .git # remove large folders
 FROM alpine as random_person_fetcher
 WORKDIR /usr/app
 RUN apk add git
-RUN git clone https://github.com/numbas/numbas-extension-random-person.git random_person
+RUN git clone https://github.com/jhoobergs/numbas-extension-random-person.git random_person
 WORKDIR /usr/app/random_person
-RUN git fetch && git checkout 4031704f9570b0ad8a6918a0dc1e8063220392a8
+RUN git fetch && git checkout prefix_compression 
 RUN rm -r .git datasets # remove large folders
 
 # Fetch download_text_file extension

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.53.0-slim as builder
+FROM rust:1.55.0-slim as builder
 
 WORKDIR /usr/app
 RUN rustup target add x86_64-unknown-linux-musl
@@ -38,7 +38,7 @@ RUN apk add git
 RUN git clone https://github.com/numbas/Numbas.git Numbas
 
 WORKDIR /usr/app/Numbas
-RUN git fetch && git checkout v6.0
+RUN git fetch && git checkout 7fb4fd4a24410316c36c3f140227fe240c5207a3
 
 # Fetch jsx graph extension
 FROM alpine as jsxgraph_fetcher
@@ -155,6 +155,9 @@ WORKDIR /usr/app/sqlite
 # Main image
 FROM python:3.6.10-alpine 
 WORKDIR /usr/app/Numbas
+
+RUN apk add yarn
+RUN yarn global add uglify-js uglifycss
 
 COPY --from=numbas_fetcher /usr/app/Numbas /usr/app/Numbas
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN apk add git
 RUN git clone https://github.com/jhoobergs/numbas-extension-random-person.git random_person
 WORKDIR /usr/app/random_person
 RUN git fetch && git checkout prefix_compression 
-RUN rm -r .git datasets # remove large folders
+RUN rm -r .git datasets compress.js lz_string.js # remove large folders
 
 # Fetch download_text_file extension
 FROM alpine as download_text_file_fetcher

--- a/rumbas/src/cli.yml
+++ b/rumbas/src/cli.yml
@@ -23,6 +23,9 @@ subcommands:
         - zip:
             short: z
             help: Create a zip file instead of a directory
+        - no-minification:
+            long: no-minification
+            help: Don't perform minification on the created js in the exam. Useful if you don't have uglifyjs or want to debug something.
   - import:
       about: |-
         Import a numbas .exam file

--- a/rumbas/src/cli/compile.rs
+++ b/rumbas/src/cli/compile.rs
@@ -49,6 +49,7 @@ pub fn compile(matches: &clap::ArgMatches) {
                                         locale,
                                         theme: exam.numbas_settings().theme,
                                         exam: res,
+                                        minify: !matches.is_present("no-minification"),
                                     };
                                     if !compiler.compile() {
                                         something_failed = true;
@@ -120,6 +121,7 @@ pub struct NumbasCompiler {
     locale: String,
     numbas_locale: String,
     theme: String,
+    minify: bool,
     exam: numbas::exam::Exam,
 }
 
@@ -190,6 +192,10 @@ impl NumbasCompiler {
         }
         if self.as_zip {
             args.push("-z");
+        }
+        if self.minify {
+            args.push("--minify");
+            args.push("uglifyjs");
         }
 
         args.push("-o");

--- a/rumbas/src/cli/compile.rs
+++ b/rumbas/src/cli/compile.rs
@@ -160,7 +160,8 @@ impl NumbasCompiler {
     /// Creates the folders in the cache folder
     /// Creates the folders in the output folder
     fn create_folder_structure(&self) -> () {
-        std::fs::create_dir_all(self.numbas_exam_folder()).expect("Failed to create cache folders");
+        std::fs::create_dir_all(self.numbas_exam_path().parent().unwrap())
+            .expect("Failed to create cache folders for the .exam file");
         std::fs::create_dir_all(self.locale_output_folder())
             .expect("Failed to create output locale folder fath");
         let output_path = self.output_path();

--- a/rumbas/src/cli/compile.rs
+++ b/rumbas/src/cli/compile.rs
@@ -196,6 +196,9 @@ impl NumbasCompiler {
         if self.minify {
             args.push("--minify");
             args.push("uglifyjs");
+
+            args.push("--minifycss");
+            args.push("uglifycss");
         }
 
         args.push("-o");

--- a/rumbas/src/cli/compile.rs
+++ b/rumbas/src/cli/compile.rs
@@ -194,10 +194,10 @@ impl NumbasCompiler {
             args.push("-z");
         }
         if self.minify {
-            args.push("--minify");
+            args.push("--minify_js");
             args.push("uglifyjs");
 
-            args.push("--minifycss");
+            args.push("--minify_css");
             args.push("uglifycss");
         }
 

--- a/rumbas/src/question/function.rs
+++ b/rumbas/src/question/function.rs
@@ -46,7 +46,7 @@ impl ToRumbas<Function> for numbas::question::function::Function {
 pub enum FunctionDefinition {
     #[serde(rename = "jme")]
     JME(FunctionDefinitionJME),
-    #[serde(rename = "js")]
+    #[serde(rename = "javascript")]
     Javascript(FunctionDefinitionJavascript),
 }
 


### PR DESCRIPTION
- Use Numbas minification feature to minify js and css files. It reduces the total size of a numbas folder by ~20%.
- Reduce rumbas docker image size by 40% (250mb to 150mb)
- Cleanup compilation code